### PR TITLE
Scan party/raid targets to find guids for nameplates.

### DIFF
--- a/ElvUI/Modules/Nameplates/Elements/HealthBar.lua
+++ b/ElvUI/Modules/Nameplates/Elements/HealthBar.lua
@@ -13,6 +13,10 @@ function NP:Update_HealthOnValueChanged()
 	NP:Update_HealthColor(frame)
 	NP:Update_Glow(frame)
 	NP:StyleFilterUpdate(frame, "UNIT_HEALTH")
+
+	if not frame.guid then
+        NP:CheckHP(frame)
+    end
 end
 
 function NP:Update_HealthColor(frame)

--- a/ElvUI/Modules/Nameplates/Nameplates.lua
+++ b/ElvUI/Modules/Nameplates/Nameplates.lua
@@ -227,7 +227,10 @@ function NP:GetUnitByName(frame, unitType)
 end
 
 function NP:GetUnitClassByGUID(frame, guid)
-	if not guid then guid = self.GUIDByName[frame.UnitName] end
+	if not guid then
+		guid = self:GetGUIDByName(frame.UnitName, frame.UnitType)
+	end
+
 	if guid then
 		local _, _, class = pcall(GetPlayerInfoByGUID, guid)
 		return class


### PR DESCRIPTION
Nameplates dont have guid information attached to them. Normally, one has to wait for a mouseover/target/focus event to match a guid to a nameplate. This adds another method -- when health changes on a nameplate, if it doesn't have a guid, then scan party/raid members' targets. If one of those targets health and max health matches a nameplate without a guid, then assign that guid to the nameplate.