### PR TITLE
Add role message on login.

### DIFF
--- a/ElvUI/Core/API.lua
+++ b/ElvUI/Core/API.lua
@@ -13,7 +13,7 @@ local UnitGroupRolesAssigned = UnitGroupRolesAssigned
 local UnitHasVehicleUI = UnitHasVehicleUI
 local IsInInstance = IsInInstance
 
-E.Role = "Melee" -- TODO: Load locally, or save per specialization.
+E.Role = "Melee" -- TODO: Save per specialization?
 
 do -- other non-english locales require this
 	E.UnlocalizedClasses = {}

--- a/ElvUI/Core/API.lua
+++ b/ElvUI/Core/API.lua
@@ -45,13 +45,8 @@ function E:ScanTooltipTextures(clean, grabTextures)
 end
 
 function E:GetPlayerRole()
-	local isTank, isHealer, isDamage = UnitGroupRolesAssigned("player")
-
-	if isTank or isHealer or isDamage then
-		return isTank and "TANK" or isHealer and "HEALER" or isDamage and "DAMAGER"
-	else
-		return "DAMAGER"  -- Assume dps role; Nothing better for ascension.
-	end
+	local isTank, isHealer, _ = UnitGroupRolesAssigned("player")
+	return isTank and "TANK" or isHealer and "HEALER" or "DAMAGER"
 end
 
 do

--- a/ElvUI/Core/Commands.lua
+++ b/ElvUI/Core/Commands.lua
@@ -237,7 +237,7 @@ function E:ChangeRole(role)
 		["tank"]="Tank",
 	}
 	E.Role = roles[lower(role)] or "Melee"
-	print("Role was changed to:", E.Role)
+	E:Print("Role was changed to "..E.Role)
 end
 
 function E:LoadCommands()
@@ -267,12 +267,7 @@ function E:LoadCommands()
 	self:RegisterChatCommand("farmmode", "FarmMode")
 	self:RegisterChatCommand("cleanguild", "MassGuildKick")
 	self:RegisterChatCommand("estatus", "ShowStatusReport")
-
-	self:RegisterChatCommand("role", "ChangeRole")
-	-- This command is added for Ascension. Role checks will be unreliable, but
-	-- this will allow one to set Role manually.
-	-- /role expects one of "melee", "caster", "ranged", "tank"
-	-- and defaults to "melee" if no role is provided.
+	self:RegisterChatCommand("/elvrole", "ChangeRole")
 
 	if E.private.actionbar.enable then
 		self:RegisterChatCommand("kb", AB.ActivateBindMode)

--- a/ElvUI/Core/Commands.lua
+++ b/ElvUI/Core/Commands.lua
@@ -267,7 +267,7 @@ function E:LoadCommands()
 	self:RegisterChatCommand("farmmode", "FarmMode")
 	self:RegisterChatCommand("cleanguild", "MassGuildKick")
 	self:RegisterChatCommand("estatus", "ShowStatusReport")
-	self:RegisterChatCommand("/elvrole", "ChangeRole")
+	self:RegisterChatCommand("elvrole", "ChangeRole")
 
 	if E.private.actionbar.enable then
 		self:RegisterChatCommand("kb", AB.ActivateBindMode)

--- a/ElvUI/Core/Core.lua
+++ b/ElvUI/Core/Core.lua
@@ -1197,7 +1197,7 @@ function E:Initialize()
 		local msg = format(L["LOGIN_MSG"], self.media.hexvaluecolor, self.media.hexvaluecolor, self.version)
 		if Chat.Initialized then msg = select(2, Chat:FindURL("CHAT_MSG_DUMMY", msg)) end
 		print(msg)
-		E:Print(format("Your role is %s. Use /role [melee, caster, ranged, tank] to change it.", E.Role))
+		E:Print("Use /elvrole [melee, caster, ranged, tank] to optimize the UI for your role. Your current role is "..E.Role)
 	end
 
 	if GetCVar("scriptProfile") ~= "1" then

--- a/ElvUI/Core/Core.lua
+++ b/ElvUI/Core/Core.lua
@@ -1197,7 +1197,7 @@ function E:Initialize()
 		local msg = format(L["LOGIN_MSG"], self.media.hexvaluecolor, self.media.hexvaluecolor, self.version)
 		if Chat.Initialized then msg = select(2, Chat:FindURL("CHAT_MSG_DUMMY", msg)) end
 		print(msg)
-		print(format("Your role is %s. Use /role [melee, caster, ranged, tank] to change it.", E.Role))
+		E:Print(format("Your role is %s. Use /role [melee, caster, ranged, tank] to change it.", E.Role))
 	end
 
 	if GetCVar("scriptProfile") ~= "1" then

--- a/ElvUI/Core/Core.lua
+++ b/ElvUI/Core/Core.lua
@@ -1203,6 +1203,7 @@ function E:Initialize()
 		local msg = format(L["LOGIN_MSG"], self.media.hexvaluecolor, self.media.hexvaluecolor, self.version)
 		if Chat.Initialized then msg = select(2, Chat:FindURL("CHAT_MSG_DUMMY", msg)) end
 		print(msg)
+		print(format("Your role is %s. Use /role [melee, caster, ranged, tank] to change it.", E.Role))
 	end
 
 	if GetCVar("scriptProfile") ~= "1" then


### PR DESCRIPTION
Role is used to determine what datatexts display (casters see spell crit on the crit datatext for instance) and threat warnings (e.g. swapped for tank role).

Original ElvUI would set roles automatically, but I removed this early on and just added /role command to set this manually. But I don't think anyone knows about this! 

It could be possible to set role automatically again by searching through known stances and/or stats, but that's beyond the scope of this pr.