### PR TITLE
Update tooltip.lua more ilvl nitpicks

### DIFF
--- a/ElvUI/Modules/Tooltip/Tooltip.lua
+++ b/ElvUI/Modules/Tooltip/Tooltip.lua
@@ -173,13 +173,17 @@ end
 function TT:GetItemLvL(unit)
 	local total, items = 0, 0
 	for i = 1, #inventorySlots do
-		local itemLink = GetInventoryItemLink(unit, GetInventorySlotInfo(inventorySlots[i]))
+		if inventorySlots[i]~="SecondaryHandSlot" and inventorySlots[i]~= "RangedSlot" then -- does not calculate offhand and ranged 
+			local itemLink = GetInventoryItemLink(unit, GetInventorySlotInfo(inventorySlots[i]))
 
-		if itemLink then
-			local iLvl = select(4, GetItemInfo(itemLink))
-			if iLvl and iLvl > 0 then
+			if itemLink then
+				local iLvl = select(4, GetItemInfo(itemLink))
+				if iLvl then
+					items = items + 1
+					total = total + iLvl
+				end
+			else --if no item equipped in slot still calculate +1 item
 				items = items + 1
-				total = total + iLvl
 			end
 		end
 	end


### PR DESCRIPTION
Previously when holding shift while hovering yourself/other player, ilvl would calculate ranged/offhand slot.
As well, if an item was not-equipped, your ilvl would go up because it did not add +1 item (therefor dividing by 1 less)

Issue still remains with inaccurate display, best guess is that it's from an error grabbing item data? Could be worth looking into, issue existed before I touched it: only changed the calculation itself.
Example: I try and look at someone iLvl by holding shift on them, tooltip says "97", I whisper to ask and they are 130, seems to only work half the time? I will look further when i have more time. 
^^
![ilvlwrong example](https://user-images.githubusercontent.com/75347238/201001611-2523c570-1f22-4ccb-927c-071c7bbd9a12.png)
^^ this player's lowest piece of gear is darkmoon card: crusade (115 ilvl) with most gear over 130, so 76.33 is incorrect.

----------------------------------------------------------------------------------------------------------------------
gonna just put this here to say thanks for what you do, cant imagine the headaches simply maintaining these addons can cause