### PR TITLE
Added DBM Pull timer, moved around buttons

### DIFF
--- a/ElvUI/Modules/Misc/RaidUtility.lua
+++ b/ElvUI/Modules/Misc/RaidUtility.lua
@@ -16,7 +16,7 @@ local InCombatLockdown = InCombatLockdown
 local DoReadyCheck = DoReadyCheck
 local ToggleFriendsFrame = ToggleFriendsFrame
 
-local PANEL_HEIGHT = 100
+local PANEL_HEIGHT = 120
 
 local function CheckRaidStatus()
 	local inInstance, instanceType = IsInInstance()
@@ -167,30 +167,13 @@ function RU:Initialize()
 	MainAssistButton:SetAttribute("unit", "target")
 	MainAssistButton:SetAttribute("action", "toggle")
 
-	self:CreateUtilButton("ReadyCheckButton", RaidUtilityPanel, nil, RaidUtilityPanel:GetWidth() * 0.8, 18, "TOPLEFT", MainTankButton, "BOTTOMLEFT", 0, -5, READY_CHECK, nil)
-	ReadyCheckButton:SetScript("OnMouseUp", function()
-		if CheckRaidStatus() then
-			DoReadyCheck()
-		end
-	end)
-	ReadyCheckButton:SetScript("OnEvent", function(btn)
-		if not (IsRaidLeader("player") or IsRaidOfficer("player")) then
-			btn:Disable()
-		else
-			btn:Enable()
-		end
-	end)
-	ReadyCheckButton:RegisterEvent("RAID_ROSTER_UPDATE")
-	ReadyCheckButton:RegisterEvent("PARTY_MEMBERS_CHANGED")
-	ReadyCheckButton:RegisterEvent("PLAYER_ENTERING_WORLD")
-
-	self:CreateUtilButton("RaidControlButton", RaidUtilityPanel, nil, MainTankButton:GetWidth(), 18, "TOPLEFT", ReadyCheckButton, "BOTTOMLEFT", 0, -5, L["Raid Menu"], nil)
+	self:CreateUtilButton("RaidControlButton", RaidUtilityPanel, nil, MainTankButton:GetWidth(), 18, "TOPLEFT", MainTankButton, "BOTTOMLEFT", 0, -5, L["Raid Menu"], nil)
 	RaidControlButton:SetScript("OnMouseUp", function()
 		if InCombatLockdown() then E:Print(ERR_NOT_IN_COMBAT) return end
 		ToggleFriendsFrame(5)
 	end)
 
-	self:CreateUtilButton("ConvertRaidButton", RaidUtilityPanel, nil, MainAssistButton:GetWidth(), 18, "TOPRIGHT", ReadyCheckButton, "BOTTOMRIGHT", 0, -5, CONVERT_TO_RAID, nil)
+	self:CreateUtilButton("ConvertRaidButton", RaidUtilityPanel, nil, MainAssistButton:GetWidth(), 18, "TOPRIGHT", MainAssistButton, "BOTTOMRIGHT", 0, -5, CONVERT_TO_RAID, nil)
 	ConvertRaidButton:SetScript("OnMouseUp", function()
 		if CheckRaidStatus() then
 			ConvertToRaid()
@@ -211,6 +194,35 @@ function RU:Initialize()
 	ConvertRaidButton:RegisterEvent("RAID_ROSTER_UPDATE")
 	ConvertRaidButton:RegisterEvent("PARTY_MEMBERS_CHANGED")
 	ConvertRaidButton:RegisterEvent("PLAYER_ENTERING_WORLD")
+
+
+	self:CreateUtilButton("ReadyCheckButton", RaidUtilityPanel, nil, RaidUtilityPanel:GetWidth() * 0.8, 18, "TOPLEFT", RaidControlButton, "BOTTOMLEFT", 0, -5, READY_CHECK, nil)
+	ReadyCheckButton:SetScript("OnMouseUp", function()
+		if CheckRaidStatus() then
+			DoReadyCheck()
+		end
+	end)
+	ReadyCheckButton:SetScript("OnEvent", function(btn)
+		if not (IsRaidLeader("player") or IsRaidOfficer("player")) then
+			btn:Disable()
+		else
+			btn:Enable()
+		end
+	end)
+	ReadyCheckButton:RegisterEvent("RAID_ROSTER_UPDATE")
+	ReadyCheckButton:RegisterEvent("PARTY_MEMBERS_CHANGED")
+	ReadyCheckButton:RegisterEvent("PLAYER_ENTERING_WORLD")
+
+	self:CreateUtilButton("DBMPullButton", RaidUtilityPanel, nil, RaidUtilityPanel:GetWidth() * 0.8, 18, "TOPLEFT", ReadyCheckButton, "BOTTOMLEFT", 0, -5, L["DBM Pull"], nil)
+	DBMPullButton:SetScript("OnMouseUp", function()
+		if InCombatLockdown() then E:Print(ERR_NOT_IN_COMBAT) return end
+		local editbox=ChatEdit_ChooseBoxForSend(DEFAULT_CHAT_FRAME);--  Get an editbox
+		ChatEdit_ActivateChat(editbox);--   Show the editbox
+		editbox:SetText("/dbm pull 10");-- Command goes here
+		ChatEdit_OnEnterPressed(editbox);
+	end)
+
+
 
 	--Automatically show/hide the frame if we have RaidLeader or RaidOfficer
 	self:RegisterEvent("RAID_ROSTER_UPDATE", "ToggleRaidUtil")

--- a/ElvUI/Modules/Misc/RaidUtility.lua
+++ b/ElvUI/Modules/Misc/RaidUtility.lua
@@ -16,7 +16,11 @@ local InCombatLockdown = InCombatLockdown
 local DoReadyCheck = DoReadyCheck
 local ToggleFriendsFrame = ToggleFriendsFrame
 
-local PANEL_HEIGHT = 120
+if IsAddOnLoaded("DBM-Core") then
+	PANEL_HEIGHT = 120
+else
+	PANEL_HEIGHT = 100
+end
 
 local function CheckRaidStatus()
 	local inInstance, instanceType = IsInInstance()
@@ -213,15 +217,27 @@ function RU:Initialize()
 	ReadyCheckButton:RegisterEvent("PARTY_MEMBERS_CHANGED")
 	ReadyCheckButton:RegisterEvent("PLAYER_ENTERING_WORLD")
 
-	self:CreateUtilButton("DBMPullButton", RaidUtilityPanel, nil, RaidUtilityPanel:GetWidth() * 0.8, 18, "TOPLEFT", ReadyCheckButton, "BOTTOMLEFT", 0, -5, L["DBM Pull"], nil)
-	DBMPullButton:SetScript("OnMouseUp", function()
-		if InCombatLockdown() then E:Print(ERR_NOT_IN_COMBAT) return end
-		local editbox=ChatEdit_ChooseBoxForSend(DEFAULT_CHAT_FRAME);--  Get an editbox
-		ChatEdit_ActivateChat(editbox);--   Show the editbox
-		editbox:SetText("/dbm pull 10");-- Command goes here
-		ChatEdit_OnEnterPressed(editbox);
-	end)
-
+	if IsAddOnLoaded("DBM-Core") then
+		self:CreateUtilButton("DBMPullButton10", RaidUtilityPanel, nil, MainTankButton:GetWidth(), 18, "TOPLEFT", ReadyCheckButton, "BOTTOMLEFT", 0, -5, L["Pull 10"], nil)
+		DBMPullButton10:SetScript("OnMouseUp", function()
+			if InCombatLockdown() then E:Print(ERR_NOT_IN_COMBAT) return end
+				-- Hacked way to make the dbm call, will update if I find the apis for it 
+				local editbox=ChatEdit_ChooseBoxForSend(DEFAULT_CHAT_FRAME)
+				ChatEdit_ActivateChat(editbox)
+				editbox:SetText("/dbm pull 10")
+				ChatEdit_OnEnterPressed(editbox)
+		end)
+	 
+		self:CreateUtilButton("DBMPullButton5", RaidUtilityPanel, nil, MainTankButton:GetWidth(), 18, "TOPRIGHT", ReadyCheckButton, "BOTTOMRIGHT", 0, -5, L["Pull 5"], nil)
+		DBMPullButton5:SetScript("OnMouseUp", function()
+			if InCombatLockdown() then E:Print(ERR_NOT_IN_COMBAT) return end
+				-- Hacked way to make the dbm call, will update if I find the apis for it 
+				local editbox=ChatEdit_ChooseBoxForSend(DEFAULT_CHAT_FRAME)
+				ChatEdit_ActivateChat(editbox)
+				editbox:SetText("/dbm pull 5")
+				ChatEdit_OnEnterPressed(editbox)
+		end)
+	end
 
 
 	--Automatically show/hide the frame if we have RaidLeader or RaidOfficer


### PR DESCRIPTION
Added DBM Pull timer button (will do nothing without DBM, calls the command through the chat) and moved around buttons so you have Ready Check and DBM Pull as the last 2 buttons (easier to use imo)

RN it doesnt check for DBM to be loaded, I can make it do so if needed (check if dbm is loaded to create the new button, if not just don't display anything and resize the panel)