### PR TITLE
fix overlap with search and new option

### DIFF
--- a/ElvUI_AddOnSkins/Skins/Addons/gnomishVendorShrinker.lua
+++ b/ElvUI_AddOnSkins/Skins/Addons/gnomishVendorShrinker.lua
@@ -33,7 +33,7 @@ S:AddCallbackForAddon("GnomishVendorShrinker", "GnomishVendorShrinker", function
 	if not GVS then return end
 
 	GVS:Size(304, 294)
-	GVS:Point("TOPLEFT", 19, -54)
+	GVS:Point("TOPLEFT", 19, -44)
 	GVS:SetTemplate("Transparent")
 
 	MerchantBuyBackItem:ClearAllPoints()
@@ -84,7 +84,7 @@ S:AddCallbackForAddon("GnomishVendorShrinker", "GnomishVendorShrinker", function
 			end
 
 			child:Height(18)
-			child:Point("TOPLEFT", GVS, "BOTTOMLEFT", 1, -61)
+			child:Point("TOPLEFT", GVS, "BOTTOMLEFT", 1, -3)
 			S:HandleEditBox(child)
 		elseif objType == "Slider" then
 			for _, child2 in ipairs({child:GetChildren()}) do
@@ -112,4 +112,8 @@ S:AddCallbackForAddon("GnomishVendorShrinker", "GnomishVendorShrinker", function
 			S:HandleScrollBar(child)
 		end
 	end
+	MerchantBuyBackItem:ClearAllPoints()
+	MerchantBuyBackItem:Point("TOPLEFT", MerchantItem10, "BOTTOMLEFT", 0, -24)
+	MerchantBuyBackItemItemButton:ClearAllPoints()
+	MerchantBuyBackItemItemButton:Point("TOPLEFT", MerchantBuyBackItem, "TOPLEFT", 4, -4)
 end)


### PR DESCRIPTION
this shifts the entire vendor window frame 10 pixels up, and squeezes in the search bar between the repair buttons and the GVS frame.

![image](https://user-images.githubusercontent.com/13251996/216880649-e15f5f41-eb00-4c64-840c-41208e8552b8.png)
