### PR TITLE
Add macro text width option

### DIFF
--- a/ElvUI/Modules/ActionBars/ActionBars.lua
+++ b/ElvUI/Modules/ActionBars/ActionBars.lua
@@ -539,6 +539,7 @@ function AB:StyleButton(button, noBackdrop, useMasque)
 
 	if macroText then
 		macroText:ClearAllPoints()
+		macroText:SetWidth(self.db.fontWidth)
 		macroText:Point("BOTTOM", 0, 1)
 		macroText:FontTemplate(LSM:Fetch("font", self.db.font), self.db.fontSize, self.db.fontOutline)
 		macroText:SetTextColor(color.r, color.g, color.b)

--- a/ElvUI/Settings/Profile.lua
+++ b/ElvUI/Settings/Profile.lua
@@ -4117,6 +4117,7 @@ P.actionbar = {
 	font = "Homespun",
 	fontSize = 10,
 	fontOutline = "MONOCHROMEOUTLINE",
+	fontWidth = 40,
 	fontColor = {r = 1, g = 1, b = 1},
 
 	macrotext = false,

--- a/ElvUI_OptionsUI/ActionBars.lua
+++ b/ElvUI_OptionsUI/ActionBars.lua
@@ -244,8 +244,15 @@ local function BuildABConfig()
 						desc = L["Set the font outline."],
 						values = C.Values.FontFlags
 					},
-					fontColor = {
+					fontWidth = {
 						order = 4,
+						type = "range",
+						name = "Font Width",
+						min = 5, max = 150, step = 1,
+						softMax = 60, softMin = 15
+					},
+					fontColor = {
+						order = 5,
 						type = "color",
 						name = L["COLOR"],
 						width = "full",
@@ -261,7 +268,7 @@ local function BuildABConfig()
 						end
 					},
 					textPosition = {
-						order = 5,
+						order = 6,
 						type = "group",
 						name = L["Text Position"],
 						guiInline = true,


### PR DESCRIPTION
Allows control over the width of the macro label displayed on the action bars. 