### PR TITLE
Add Ascension specific frame skins

### DIFF
--- a/ElvUI/Modules/Skins/Blizzard/Debug.lua
+++ b/ElvUI/Modules/Skins/Blizzard/Debug.lua
@@ -8,6 +8,25 @@ local unpack = unpack
 S:AddCallbackForAddon("Blizzard_DebugTools", "Skin_Blizzard_DebugTools", function()
 	if not E.private.skins.blizzard.enable or not E.private.skins.blizzard.debug then return end
 
+	-- Error Handler Frame (AKA BugSack)
+	ErrorHandler:StripTextures()
+	ErrorHandler.NineSlice:StripTextures()
+	ErrorHandler:CreateBackdrop("Transparent")
+	ErrorHandler.backdrop:Point("TOPLEFT", 0, 0)
+	ErrorHandler.backdrop:Point("BOTTOMRIGHT", 0, 0)
+	S:HandleScrollBar(ErrorHandlerErrorScrollBar)
+	ErrorHandlerErrorScrollBarScrollDownButton:Point("TOP", ErrorHandlerErrorScrollBar, "BOTTOM", 0, 2)
+
+	S:HandleTabSystem(ErrorHandler)
+	S:HandleButton(ErrorHandlerPreviousButton)
+	S:HandleButton(ErrorHandlerCopyButton)
+	S:HandleButton(ErrorHandlerNextButton)
+
+	S:HandleCloseButton(ErrorHandlerCloseButton)
+
+	ErrorHandlerErrorInset:StripTextures()
+
+	-- Script Error Frame
 	ScriptErrorsFrame:SetParent(E.UIParent)
 	ScriptErrorsFrame:StripTextures()
 	ScriptErrorsFrame:SetTemplate("Transparent")

--- a/ElvUI/Modules/Skins/Blizzard/Load_Blizzard.xml
+++ b/ElvUI/Modules/Skins/Blizzard/Load_Blizzard.xml
@@ -30,6 +30,7 @@
 	<Script file="Merchant.lua"/>
 	<Script file="MirrorTimers.lua"/>
 	<Script file="Misc.lua"/>
+	<Script file="PathToAscension.lua"/>
 	<Script file="Petition.lua"/>
 	<Script file="PvP.lua"/>
 	<Script file="Quest.lua"/>

--- a/ElvUI/Modules/Skins/Blizzard/PathToAscension.lua
+++ b/ElvUI/Modules/Skins/Blizzard/PathToAscension.lua
@@ -1,0 +1,62 @@
+local E, L, V, P, G = unpack(ElvUI)
+local S = E:GetModule("Skins")
+
+local unpack = unpack
+
+S:AddCallbackForAddon("Ascension_PathToAscension", "Skin_PathToAscension", function ()
+	if not E.private.skins.blizzard.enable or not E.private.skins.blizzard.pathtoascension then return end
+
+	PathToAscensionFrame:StripTextures()
+	PathToAscensionFramePortraitFrame:StripTextures()
+	-- Strip Border Textures
+	PathToAscensionFrameNineSlice:StripTextures()
+	PathToAscensionFrameDisplayNineSlice:StripTextures()
+	PathToAscensionFrameObjectivesInsetFrame:StripTextures()
+
+	PathToAscensionFrameMentorPanel:StripTextures()
+
+	PathToAscensionFrame:CreateBackdrop("Transparent")
+
+	-- Strip Objective Panel Frame textures
+	PathToAscensionFrameDisplay:StripTextures()
+	PathToAscensionFrameDisplayQuestObjectives:StripTextures()
+
+	-- Reskin the Frames in ElvUI style
+	S:HandleEditBox(PathToAscensionFrameObjectivesHeaderSearch)
+
+	S:HandleScrollBar(PathToAscensionFrameObjectivesScrollFrameScrollBar)
+	S:HandleButton(PathToAscensionFrameDisplayQuestObjectivesInteractButton)
+	S:HandleButton(PathToAscensionFrameDisplayLeftButton)
+	S:HandleButton(PathToAscensionFrameDisplayRightButton)
+
+
+	S:HandleTabSystem(PathToAscensionFrame)
+
+	-- sRGB values pulled from Achievement.lua
+	local sbcR, sbcG, sbcB = 4/255, 179/255, 30/255
+
+	local function skinStatusBar(bar)
+		bar:StripTextures()
+		bar:SetBackgroundTexture()
+		bar:SetStatusBarTexture(E.media.normTex)
+		bar:SetStatusBarColor(sbcR, sbcG, sbcB)
+		-- Clear out Unnamed Frames backdrop
+		local children = {bar:GetChildren()}
+		for i, child in ipairs(children) do
+			child:SetBackdrop(nil)
+		end
+	
+		E:RegisterStatusBar(bar)
+	end
+
+	skinStatusBar(PathToAscensionFrameCompleteProgressRewardProgress)
+
+	PathToAscensionFrameObjectivesScrollFrameArtOverlay:StripTextures(true)
+
+	-- Reskin the objectives list
+	for i = 1, 12 do
+		local objectiveButton = _G["PathToAscensionFrameObjectivesScrollFrameButton"..i]
+		S:HandleButton(objectiveButton, true)
+	end
+
+end)

--- a/ElvUI_OptionsUI/Skins.lua
+++ b/ElvUI_OptionsUI/Skins.lua
@@ -208,6 +208,11 @@ E.Options.args.skins = {
 					name = L["Mirror Timers"],
 					desc = L["TOGGLESKIN_DESC"]
 				},
+				pathtoascension = {
+					type = "toggle",
+					name = L["Path To Ascension"],
+					desc = L["TOGGLESKIN_DESC"]
+				},
 				petition = {
 					type = "toggle",
 					name = L["Petition Frame"],


### PR DESCRIPTION
* Adds ElvUI styling to PathToAscension frame
* Adds ElvUI styling to ErrorHandler frame (bugsack)

Note: unsure how to add localization for new options string.

View from PTR Client:

![image](https://github.com/user-attachments/assets/f8b0d97f-e755-45dc-8bce-df0d76b251b7)

Note: searchbox was not reskinned in the screenshot I can grab a new one showing fixed if desired
![image](https://github.com/user-attachments/assets/7769f336-721e-4a69-b7e1-37cd056f99f3)

