### PR TITLE
WorldMap Fixes and Mentor Panel Skin

### DIFF
--- a/ElvUI/ElvUI.toc
+++ b/ElvUI/ElvUI.toc
@@ -1,6 +1,6 @@
 ## Interface: 30300
 ## Author: Elv, Bunny
-## Version: 7.19
+## Version: 7.20
 ## Title: |cff1784d1E|r|cffe5e3e3lvUI|r
 ## Notes: User Interface replacement AddOn for World of Warcraft.
 ## SavedVariables: ElvDB, ElvPrivateDB

--- a/ElvUI/Modules/Skins/Blizzard/LFD.lua
+++ b/ElvUI/Modules/Skins/Blizzard/LFD.lua
@@ -37,6 +37,9 @@ S:AddCallback("Skin_LFD", function()
 	AscensionLFGFrame:StripTextures(true)
 	AscensionLFGFrame.PortraitFrame:StripTextures(true)
 	AscensionLFGFrame:CreateBackdrop("Transparent")
+	-- Remove the Vertical Gold bar between menu frame and content frame
+	local childFrames={AscensionLFGFrame:GetChildren()}
+	childFrames[13]:StripTextures()
 	AscensionLFGFrameContent:StripTextures(true)
 	AscensionLFGFrameMenu:StripTextures(true)
 	AscensionLFGFrameInset:StripTextures(true)

--- a/ElvUI/Modules/Skins/Blizzard/LFD.lua
+++ b/ElvUI/Modules/Skins/Blizzard/LFD.lua
@@ -12,6 +12,25 @@ local GetLFGDungeonRewardLink = GetLFGDungeonRewardLink
 local GetLFGDungeonRewards = GetLFGDungeonRewards
 local hooksecurefunc = hooksecurefunc
 
+-- Manastorm is injected into Blizz frames from a separate addon
+S:AddCallbackForAddon("Ascension_Manastorm", "Skin_Manastorm", function()
+	if not E.private.skins.blizzard.enable or not E.private.skins.blizzard.lfd then return end
+
+	ManastormQueueFrameInset:StripTextures()
+	ManastormQueueFrameCurrencyBar:StripTextures()
+	ManastormQueueFrameRightPanelLevelSelect:StripTextures()
+	ManastormQueueFrameRightPanelLevelSelect:CreateBackdrop("Transparent")
+	S:HandleButton(ManastormQueueFrameRightPanelEnterButton)
+	S:HandleButton(ManastormQueueFrameRightPanelLevelDropDown)
+	ManastormQueueFrameRightPanelLevelDropDown:SetSize(120, 24)
+	ManastormQueueFrameRightPanelLevelDropDown:SetPoint("BOTTOMRIGHT", ManastormQueueFrameRightPanelEnterButton, "TOPRIGHT")
+	S:HandleNextPrevButton(ManastormQueueFrameRightPanelLevelDropDown.Button, "down")
+	ManastormQueueFrameRightPanelLevelDropDown.Button:SetPoint("RIGHT", ManastormQueueFrameRightPanelLevelDropDown, "RIGHT", -2, 0)
+	S:HandleScrollList(ManastormQueueFrameRightPanelLevelSelectScrollList)
+	ManastormQueueFrameRightPanelLevelSelect:SetPoint("BOTTOMRIGHT", ManastormQueueFrameRightPanelLevelDropDown, "TOPRIGHT", -1, 0)
+	ManastormQueueFrameRightPanelLevelSelectScrollList:CreateBackdrop("Default")
+end)
+
 S:AddCallback("Skin_LFD", function()
 	if not E.private.skins.blizzard.enable or not E.private.skins.blizzard.lfd then return end
 

--- a/ElvUI/Modules/Skins/Blizzard/LFD.lua
+++ b/ElvUI/Modules/Skins/Blizzard/LFD.lua
@@ -131,41 +131,51 @@ S:AddCallback("Skin_LFD", function()
 			--Arena
 			S:HandleStatusBar(AscensionPVPFrameArenaBar)
 
-		-- Quick Match
-		AscensionPVPFrame:StripTextures(true)
-		AscensionPVPFrame:CreateBackdrop("Transparent")
-		AscensionPVPFrameCasualFrame:StripTextures(true)
-		AscensionPVPFrameCasualFrame:CreateBackdrop("Transparent")
-		AscensionPVPFrameCasualFrameInset:StripTextures(true)
-		AscensionPVPFrameCasualFrameInset:CreateBackdrop("Transparent")
-		AscensionPVPFrameCasualFrameInsetNineSlice:StripTextures(true)
-			-- Buttons (Queues)
-			S:HandleButton(AscensionPVPFrameCasualFrameRandomBGButton)
-			S:HandleButton(AscensionPVPFrameCasualFrameCallToArmsButton1)
-			S:HandleButton(AscensionPVPFrameCasualFrameSkirmish1v1Button)
-			S:HandleButton(AscensionPVPFrameCasualFrameSkirmish2v2Button)
-			S:HandleButton(AscensionPVPFrameCasualFrameSkirmish3v3Button)
-		-- Honor Section
-		AscensionPVPFrameHonorInset:StripTextures(true)
-		AscensionPVPFrameHonorInset:CreateBackdrop("Transparent")
-		AscensionPVPFrameHonorInsetNineSlice:StripTextures(true)
+			-- Quick Match
+	AscensionPVPFrame:StripTextures(true)
+	AscensionPVPFrame:CreateBackdrop("Transparent")
+	AscensionPVPFrameCasualFrame:StripTextures(true)
+	AscensionPVPFrameCasualFrame:CreateBackdrop("Transparent")
+	AscensionPVPFrameCasualFrameInset:StripTextures(true)
+	AscensionPVPFrameCasualFrameInset:CreateBackdrop("Transparent")
+	AscensionPVPFrameCasualFrameInsetNineSlice:StripTextures(true)
+	-- Fix inset textures on the casual frame
+	local casualFrame = {AscensionPVPFrameCasualFrame:GetChildren()}
+	casualFrame[2]:StripTextures()
+	AscensionPVPFrameStatsInset:StripTextures()
+	AscensionPVPFrameStatsInsetNineSlice:StripTextures(true)
+	-- Buttons (Queues)
+	S:HandleButton(AscensionPVPFrameCasualFrameRandomBGButton)
+	S:HandleButton(AscensionPVPFrameCasualFrameCallToArmsButton1)
+	S:HandleButton(AscensionPVPFrameCasualFrameSkirmish1v1Button)
+	S:HandleButton(AscensionPVPFrameCasualFrameSkirmish2v2Button)
+	S:HandleButton(AscensionPVPFrameCasualFrameSkirmish3v3Button)
+	-- Honor Section
+	AscensionPVPFrameHonorInset:StripTextures(true)
+	AscensionPVPFrameHonorInset:CreateBackdrop("Transparent")
+	AscensionPVPFrameHonorInsetNineSlice:StripTextures(true)
 
-		-- Buttons
-		S:HandleButton(AscensionPVPFrameCasualFrameQueueButton)
-		S:HandleButton(AscensionPVPFrameCasualFrameSoloQueueButton)
+	-- Buttons
+	S:HandleButton(AscensionPVPFrameCasualFrameQueueButton)
+	AscensionPVPFrameCasualFrameQueueButton:SetSize(150, 28)
+	S:HandleButton(AscensionPVPFrameCasualFrameSoloQueueButton)
+	AscensionPVPFrameCasualFrameSoloQueueButton:SetSize(150, 28)
+	S:HandleButton(AscensionPVPFrameCasualFrameLeaveQueueButton)
+	AscensionPVPFrameCasualFrameLeaveQueueButton:SetSize(150, 28)
 
-		--Rated Tab
-		AscensionPVPFrameRatedFrame:StripTextures(true)
-		AscensionPVPFrameRatedFrame:CreateBackdrop("Transparent")
-		AscensionPVPFrameRatedFrameInset:StripTextures(true)
-		AscensionPVPFrameRatedFrameInset:CreateBackdrop("Transparent")
-		AscensionPVPFrameRatedFrameInsetNineSlice:StripTextures(true)
-			-- Buttons (Rated)
-			S:HandleButton(AscensionPVPFrameRatedFrameArena1v1)
-			S:HandleButton(AscensionPVPFrameRatedFrameArena2v2)
-			S:HandleButton(AscensionPVPFrameRatedFrameArena3v3)
-			S:HandleButton(AscensionPVPFrameRatedFrameSoloQueueButton)
-			S:HandleButton(AscensionPVPFrameRatedFrameQueueButton)
+	--Rated Tab
+	AscensionPVPFrameRatedFrame:StripTextures(true)
+	AscensionPVPFrameRatedFrame:CreateBackdrop("Transparent")
+	AscensionPVPFrameRatedFrameInset:StripTextures(true)
+	AscensionPVPFrameRatedFrameInset:CreateBackdrop("Transparent")
+	AscensionPVPFrameRatedFrameInsetNineSlice:StripTextures(true)
+
+	-- Buttons (Rated)
+	S:HandleButton(AscensionPVPFrameRatedFrameArena1v1)
+	S:HandleButton(AscensionPVPFrameRatedFrameArena2v2)
+	S:HandleButton(AscensionPVPFrameRatedFrameArena3v3)
+	S:HandleButton(AscensionPVPFrameRatedFrameSoloQueueButton)
+	S:HandleButton(AscensionPVPFrameRatedFrameQueueButton)
 
 	-- PvP Ruleset
 	AscensionRulesetFrame:StripTextures(true)

--- a/ElvUI/Modules/Skins/Blizzard/PathToAscension.lua
+++ b/ElvUI/Modules/Skins/Blizzard/PathToAscension.lua
@@ -71,7 +71,7 @@ S:AddCallbackForAddon("Ascension_PathToAscension", "Skin_PathToAscension", funct
 	PathToAscensionFrameObjectivesScrollFrameArtOverlay:StripTextures(true)
 
 	-- Reskin the objectives list
-	for i = 1, 12 do
+	for i = 1, 13 do
 		local objectiveButton = _G["PathToAscensionFrameObjectivesScrollFrameButton"..i]
 		S:HandleButton(objectiveButton, true)
 	end

--- a/ElvUI/Modules/Skins/Blizzard/PathToAscension.lua
+++ b/ElvUI/Modules/Skins/Blizzard/PathToAscension.lua
@@ -14,21 +14,38 @@ S:AddCallbackForAddon("Ascension_PathToAscension", "Skin_PathToAscension", funct
 	PathToAscensionFrameObjectivesInsetFrame:StripTextures()
 
 	PathToAscensionFrameMentorPanel:StripTextures()
+	PathToAscensionFrameMentorPanelBecomeMentor:StripTextures()
+	PathToAscensionFrameMentorPanelBecomeMentorBorder:StripTextures()
+	PathToAscensionFrameMentorPanelFindHelp:StripTextures()
+	PathToAscensionFrameMentorPanelFindHelpBorder:StripTextures()
+	-- Strip Frame Inset from AvailableMentors list
+	local mentorFrameChildren = {PathToAscensionFrameMentorPanelFindHelpAvailableMentors:GetChildren()}
+	mentorFrameChildren[2]:StripTextures()
+
 
 	PathToAscensionFrame:CreateBackdrop("Transparent")
+	PathToAscensionFrameMentorPanelBecomeMentor:CreateBackdrop("Transparent")
+	PathToAscensionFrameMentorPanelFindHelp:CreateBackdrop("Transparent")
 
 	-- Strip Objective Panel Frame textures
 	PathToAscensionFrameDisplay:StripTextures()
 	PathToAscensionFrameDisplayQuestObjectives:StripTextures()
 
 	-- Reskin the Frames in ElvUI style
+	S:HandleCloseButton(PathToAscensionFrameCloseButton)
 	S:HandleEditBox(PathToAscensionFrameObjectivesHeaderSearch)
+	S:HandleEditBox(PathToAscensionFrameMentorPanelFindHelpSearchBox)
 
 	S:HandleScrollBar(PathToAscensionFrameObjectivesScrollFrameScrollBar)
 	S:HandleButton(PathToAscensionFrameDisplayQuestObjectivesInteractButton)
 	S:HandleButton(PathToAscensionFrameDisplayLeftButton)
 	S:HandleButton(PathToAscensionFrameDisplayRightButton)
 
+	S:HandleButton(PathToAscensionFrameMentorPanelBecomeMentorBecomeMentorButton)
+	S:HandleButton(PathToAscensionFrameMentorPanelFindHelpRefreshButton)
+	PathToAscensionFrameMentorPanelFindHelpRefreshButton:Size(22, 22)
+
+	S:HandleScrollList(PathToAscensionFrameMentorPanelFindHelpAvailableMentors)
 
 	S:HandleTabSystem(PathToAscensionFrame)
 
@@ -59,4 +76,19 @@ S:AddCallbackForAddon("Ascension_PathToAscension", "Skin_PathToAscension", funct
 		S:HandleButton(objectiveButton, true)
 	end
 
+	-- Reskin Mentor Checkboxes
+	for i = 1, 10 do
+		local checkBox = _G["PathToAscensionFrameMentorPanelBecomeMentorSpecialization"..i]
+		S:HandleCheckBox(checkBox)
+	end
+
+	-- Reskin Available Mentors
+	for i = 1, 9 do
+		local mentor = _G["PathToAscensionFrameMentorPanelFindHelpAvailableMentorsScrollFrameButton"..i] 
+		S:HandleButton(mentor, true)
+	end
+
+	PathToAscensionFrameMentorPanelFindHelpFilter:StripTextures(true)
+	S:HandleButton(PathToAscensionFrameMentorPanelFindHelpFilter)
+	
 end)

--- a/ElvUI/Modules/Skins/Blizzard/Worldmap.lua
+++ b/ElvUI/Modules/Skins/Blizzard/Worldmap.lua
@@ -36,13 +36,17 @@ S:AddCallback("Skin_WorldMap", function()
 
 	WorldMapQuestDetailScrollFrameTrack:Kill()
 
-	WorldMapQuestRewardScrollFrame:Width(340)
-	WorldMapQuestRewardScrollFrame:Point("LEFT", WorldMapQuestDetailScrollFrame, "RIGHT", 8, 0)
+	WorldMapQuestRewardScrollFrame:Width(320)
+	WorldMapQuestRewardScrollFrame:Point("LEFT", WorldMapQuestDetailScrollFrame, "RIGHT", -2, 0)
 	WorldMapQuestRewardScrollFrame:CreateBackdrop("Transparent")
-	WorldMapQuestRewardScrollFrame.backdrop:Point("TOPLEFT", 20, 2)
-	WorldMapQuestRewardScrollFrame.backdrop:Point("BOTTOMRIGHT", 22, -4)
+	WorldMapQuestRewardScrollFrame.backdrop:Point("TOPLEFT", -3, 2)
+	WorldMapQuestRewardScrollFrame.backdrop:Point("BOTTOMRIGHT", 21, 0)
 	WorldMapQuestRewardScrollFrame.backdrop:SetFrameLevel(WorldMapQuestRewardScrollFrame:GetFrameLevel())
-	WorldMapQuestRewardScrollFrame:SetHitRectInsets(20, -22, 0, -2)
+	S:HandleButton(WorldMapQuestRewardScrollFrameShareButton)
+	WorldMapQuestRewardScrollFrameShareButton:Width(120)
+	S:HandleButton(WorldMapQuestRewardScrollFrameAbandonButton)
+	WorldMapQuestRewardScrollFrameAbandonButton:Width(120)
+	
 
 	WorldMapQuestRewardScrollChildFrame:SetScale(1)
 


### PR DESCRIPTION
- Fixes unskinned buttons in QuestReward Frame of WorldMap
- Fixes incorrect background sizings and offsets for QuestRewardFrame in WorldMap
- Adds skinning of PathToAscension Mentor Panel
- Fixes close button for PathToAscension Frame  still using blizzard textures
- Fix 13th objective button being unskinned from the PTA Frame
- Fix some leftover Blizzard Skins in the LFG PVP Frame
- Remove Gold separator from LFD/LFG Frame
- Add Skinning to manastorm frame

![{D8050B77-02A6-4BB1-84BE-C519218A6DD4}](https://github.com/user-attachments/assets/fbc3b8a5-d96d-442a-9b20-409596ef37e2)

![{4848462D-6C2D-4261-B48D-91534110D635}](https://github.com/user-attachments/assets/506a9e96-d024-4d26-ba48-2c9efdc66253)

![image](https://github.com/user-attachments/assets/7e6a778e-123d-44c6-9de1-99e018cc5f8b)

![{A66E4935-1583-4AFA-AB5F-99F762E789A5}](https://github.com/user-attachments/assets/d6a1811f-b386-496d-8e5f-f7d9e11ce22e)

