### PR TITLE
Fix Options Menu, Risk choice, and few missed buttons 

### DIFF
--- a/ElvUI/ElvUI.toc
+++ b/ElvUI/ElvUI.toc
@@ -1,6 +1,6 @@
 ## Interface: 30300
 ## Author: Elv, Bunny
-## Version: 7.20
+## Version: 7.21
 ## Title: |cff1784d1E|r|cffe5e3e3lvUI|r
 ## Notes: User Interface replacement AddOn for World of Warcraft.
 ## SavedVariables: ElvDB, ElvPrivateDB

--- a/ElvUI/Modules/Skins/Blizzard/BlizzardOptions.lua
+++ b/ElvUI/Modules/Skins/Blizzard/BlizzardOptions.lua
@@ -123,12 +123,15 @@ S:AddCallback("Skin_BlizzardOptions", function()
 		"InterfaceOptionsControlsPanelAutoDismount",
 		"InterfaceOptionsControlsPanelAutoClearAFK",
 		"InterfaceOptionsControlsPanelBlockTrades",
-		"InterfaceOptionsControlsPanelLootAtMouse",
-		"InterfaceOptionsControlsPanelAutoLootCorpse",
+		"InterfaceOptionsControlsPanelLootAtMouse", -- Old Name?
+		"InterfaceOptionsControlsPanelLootUnderMouse",
+		"InterfaceOptionsControlsPanelAutoLootCorpse", -- Old Name?
+		"InterfaceOptionsControlsPanelAutoLootDefault",
 		"InterfaceOptionsControlsPanelTabTargetFacing",
 		"InterfaceOptionsControlsPanelTabTargetCombat",
 		"InterfaceOptionsControlsPanelTabTargetPlayers",
-		"InterfaceOptionsControlsPanelHoldToCast",
+		"InterfaceOptionsControlsPanelHoldToCast", -- Moved to Combat panel?
+
 		"InterfaceOptionsCombatPanelAttackOnAssist",
 		"InterfaceOptionsCombatPanelAutoRange",
 		"InterfaceOptionsCombatPanelStopAutoAttack",
@@ -137,22 +140,36 @@ S:AddCallback("Skin_BlizzardOptions", function()
 		"InterfaceOptionsCombatPanelTargetOfTarget",
 		"InterfaceOptionsCombatPanelEnemyCastBarsOnPortrait",
 		"InterfaceOptionsCombatPanelEnemyCastBarsOnNameplates",
-		"InterfaceOptionsCombatPanelAoEIndicatorsSelf",
-		"InterfaceOptionsCombatPanelAoEIndicatorsEnemies",
-		"InterfaceOptionsCombatPanelAoEIndicatorsFriendly",
+		"InterfaceOptionsCombatPanelAoEIndicatorsSelf", -- Old Name?
+		"InterfaceOptionsCombatPanelSelf",
+		"InterfaceOptionsCombatPanelAoEIndicatorsEnemies", -- Old Name?
+		"InterfaceOptionsCombatPanelEnemies",
+		"InterfaceOptionsCombatPanelAoEIndicatorsFriendly", -- Old Name?
+		"InterfaceOptionsCombatPanelFriendly",
+		"InterfaceOptionsCombatPanelSpellActivationOverlayEnabled",
+		"InterfaceOptionsCombatPanelAutoAssistCast",
+		"InterfaceOptionsCombatPanelSpellShadowShowBad",
+		"InterfaceOptionsCombatPanelHoldToCast",
+
 		"InterfaceOptionsDisplayPanelShowCloak",
 		"InterfaceOptionsDisplayPanelShowHelm",
 		"InterfaceOptionsDisplayPanelShowAggroPercentage",
-		"InterfaceOptionsDisplayPanelPlayAggroSounds",
-		"InterfaceOptionsDisplayPanelDetailedLootInfo",
-		"InterfaceOptionsDisplayPanelShowFreeBagSpace",
-		"InterfaceOptionsDisplayPanelCinematicSubtitles",
+		"InterfaceOptionsDisplayPanelPlayAggroSounds", -- Old Name?
+		"InterfaceOptionsDisplayPanelThreatPlaySounds",
+		"InterfaceOptionsDisplayPanelDetailedLootInfo", -- Old Name?
+		"InterfaceOptionsDisplayPanelShowLootSpam",
+		"InterfaceOptionsDisplayPanelShowFreeBagSpace", -- Old Name?
+		"InterfaceOptionsDisplayPanelDisplayFreeBagSlots",
+		"InterfaceOptionsDisplayPanelCinematicSubtitles", -- Old Name?
+		"InterfaceOptionsDisplayPanelMovieSubtitle",
 		"InterfaceOptionsDisplayPanelRotateMinimap",
 		"InterfaceOptionsDisplayPanelScreenEdgeFlash",
 		"InterfaceOptionsDisplayPanelShowClock",
 		"InterfaceOptionsDisplayPanelColorblindMode",
 		"InterfaceOptionsDisplayPanelShowItemLevel",
 		"InterfaceOptionsDisplayPanelHighlightNewItems",
+		"InterfaceOptionsDisplayPanelSelectionCircleMode",
+
 		"InterfaceOptionsObjectivesPanelInstantQuestText",
 		"InterfaceOptionsObjectivesPanelAutoQuestTracking",
 		"InterfaceOptionsObjectivesPanelAutoQuestProgress",
@@ -160,15 +177,20 @@ S:AddCallback("Skin_BlizzardOptions", function()
 		"InterfaceOptionsObjectivesPanelAdvancedWorldMap",
 		"InterfaceOptionsObjectivesPanelWatchFrameWidth",
 		"InterfaceOptionsObjectivesPanelPTAQuests",
+		"InterfaceOptionsObjectivesPanelInGameNavigation",
+		"InterfaceOptionsObjectivesPanelShowQuestUnitCircles",
+
 		"InterfaceOptionsSocialPanelProfanityFilter",
 		"InterfaceOptionsSocialPanelSpamFilter",
 		"InterfaceOptionsSocialPanelChatBubbles",
+		"InterfaceOptionsSocialPanelNameplateChatBubbles",
 		"InterfaceOptionsSocialPanelPartyChat",
 		"InterfaceOptionsSocialPanelChatHoverDelay",
 		"InterfaceOptionsSocialPanelGuildMemberAlert",
 		"InterfaceOptionsSocialPanelGuildRecruitment",
 		"InterfaceOptionsSocialPanelChatMouseScroll",
 		"InterfaceOptionsSocialPanelWholeChatWindowClickable",
+
 		"InterfaceOptionsActionBarsPanelLockActionBars",
 		"InterfaceOptionsActionBarsPanelSecureAbilityToggle",
 		"InterfaceOptionsActionBarsPanelAlwaysShowActionBars",
@@ -176,6 +198,7 @@ S:AddCallback("Skin_BlizzardOptions", function()
 		"InterfaceOptionsActionBarsPanelBottomRight",
 		"InterfaceOptionsActionBarsPanelRight",
 		"InterfaceOptionsActionBarsPanelRightTwo",
+
 		"InterfaceOptionsNamesPanelMyName",
 		"InterfaceOptionsNamesPanelFriendlyPlayerNames",
 		"InterfaceOptionsNamesPanelFriendlyPets",
@@ -190,6 +213,25 @@ S:AddCallback("Skin_BlizzardOptions", function()
 		"InterfaceOptionsNamesPanelEnemyPets",
 		"InterfaceOptionsNamesPanelEnemyGuardians",
 		"InterfaceOptionsNamesPanelEnemyTotems",
+		
+		-- Ascension Nameplate options
+		"InterfaceOptionsNamePlatesPanelUseSmoothStacking",
+		"InterfaceOptionsNamePlatesPanelUseFriendlySmoothStacking",
+		"InterfaceOptionsNamePlatesPanelNameplateHighPrecision",
+		"InterfaceOptionsNamePlatesPanelNameplateClassColors",
+		"InterfaceOptionsNamePlatesPanelIntersectUseCamera",
+		"InterfaceOptionsNamePlatesPanelFixedVerticalOffset",
+		"InterfaceOptionsNamePlatesPanelNameplatePersonal",
+		"InterfaceOptionsNamePlatesPanelFriends",
+		"InterfaceOptionsNamePlatesPanelFriendlyPets",
+		"InterfaceOptionsNamePlatesPanelFriendlyGuardians",
+		"InterfaceOptionsNamePlatesPanelFriendlyTotems",
+		"InterfaceOptionsNamePlatesPanelUseNewNameplates",
+		"InterfaceOptionsNamePlatesPanelEnemies",
+		"InterfaceOptionsNamePlatesPanelEnemyPets",
+		"InterfaceOptionsNamePlatesPanelEnemyGuardians",
+		"InterfaceOptionsNamePlatesPanelEnemyTotems",
+
 		"InterfaceOptionsCombatTextPanelTargetDamage",
 		"InterfaceOptionsCombatTextPanelPeriodicDamage",
 		"InterfaceOptionsCombatTextPanelPetDamage",
@@ -209,29 +251,38 @@ S:AddCallback("Skin_BlizzardOptions", function()
 		"InterfaceOptionsCombatTextPanelPeriodicEnergyGains",
 		"InterfaceOptionsCombatTextPanelHonorGains",
 		"InterfaceOptionsCombatTextPanelAuras",
+
 		"InterfaceOptionsBuffsPanelBuffDurations",
 		"InterfaceOptionsBuffsPanelDispellableDebuffs",
 		"InterfaceOptionsBuffsPanelCastableBuffs",
 		"InterfaceOptionsBuffsPanelConsolidateBuffs",
 		"InterfaceOptionsBuffsPanelShowCastableDebuffs",
+
 		"InterfaceOptionsCameraPanelFollowTerrain",
 		"InterfaceOptionsCameraPanelHeadBob",
 		"InterfaceOptionsCameraPanelWaterCollision",
 		"InterfaceOptionsCameraPanelSmartPivot",
+		"InterfaceOptionsCameraPanelM2Collision",
+
 		"InterfaceOptionsMousePanelInvertMouse",
 		"InterfaceOptionsMousePanelClickToMove",
 		"InterfaceOptionsMousePanelWoWMouse",
-		"InterfaceOptionsHelpPanelShowTutorials",
+
+		"InterfaceOptionsHelpPanelShowTutorials", -- Old option?
 		"InterfaceOptionsHelpPanelLoadingScreenTips",
-		"InterfaceOptionsHelpPanelEnhancedTooltips",
-		"InterfaceOptionsHelpPanelBeginnerTooltips",
 		"InterfaceOptionsHelpPanelShowLuaErrors",
+		"InterfaceOptionsHelpPanelEnhancedTooltips", -- Old option?
+		"InterfaceOptionsHelpPanelExtendedTooltips",
+		"InterfaceOptionsHelpPanelBeginnerTooltips",
+		"InterfaceOptionsHelpPanelShowTooltipIDs",
+
 		"InterfaceOptionsStatusTextPanelPlayer",
 		"InterfaceOptionsStatusTextPanelPet",
 		"InterfaceOptionsStatusTextPanelParty",
 		"InterfaceOptionsStatusTextPanelTarget",
 		"InterfaceOptionsStatusTextPanelPercentages",
 		"InterfaceOptionsStatusTextPanelXP",
+
 		"InterfaceOptionsUnitFramePanelPartyBackground",
 		"InterfaceOptionsUnitFramePanelPartyPets",
 		"InterfaceOptionsUnitFramePanelArenaEnemyFrames",
@@ -240,9 +291,17 @@ S:AddCallback("Skin_BlizzardOptions", function()
 		"InterfaceOptionsUnitFramePanelPartyInRaid",
 		"InterfaceOptionsUnitFramePanelRaidRange",
 		"InterfaceOptionsUnitFramePanelFullSizeFocusFrame",
+
 		"InterfaceOptionsFeaturesPanelPreviewTalentChanges",
 		"InterfaceOptionsFeaturesPanelEquipmentManager",
+
 		"InterfaceOptionsAscensionNotificationPanelLootToast",
+		"InterfaceOptionsAscensionNotificationPanelEnableItems",
+		"InterfaceOptionsAscensionNotificationPanelEnableNewSpellRanks",
+		"InterfaceOptionsAscensionNotificationPanelFlashWindow",
+		"InterfaceOptionsAscensionNotificationPanelEnableLegendaryItems",
+		"InterfaceOptionsAscensionNotificationPanelEnableNewSpells",
+
 		"InterfaceOptionsAscensionLoseControlPanelEnabled",
 		"InterfaceOptionsAscensionLoseControlPanelEnableRoots",
 		"InterfaceOptionsAscensionLoseControlPanelEnableSilence",
@@ -252,11 +311,13 @@ S:AddCallback("Skin_BlizzardOptions", function()
 		"InterfaceOptionsAscensionLoseControlPanelEnableSlow",
 		"InterfaceOptionsAscensionLoseControlPanelEnableStun",
 		"InterfaceOptionsAscensionLoseControlPanelEnablePacify",
+
 		"InterfaceOptionsDraftPanelAutoPopupDraft",
 		"InterfaceOptionsDraftPanelAutoRevealDraft",
 		"InterfaceOptionsDraftPanelSkipDraftConfirmation",
 		"InterfaceOptionsDraftPanelSkipDraftSacrificeConfirmation",
 		"InterfaceOptionsDraftPanelShowBuildDraftSpellCards",
+
 		"InterfaceOptionsNamePlatePanelAllowOverlap",
 		"InterfaceOptionsNamePlatePanelFriends",
 		"InterfaceOptionsNamePlatePanelFriendlyPets",
@@ -267,12 +328,48 @@ S:AddCallback("Skin_BlizzardOptions", function()
 		"InterfaceOptionsNamePlatePanelEnemyGuardians",
 		"InterfaceOptionsNamePlatePanelEnemyTotems",
 		"InterfaceOptionsNamePlatePanelIntersectUseCamera",
+
 		"InterfaceOptionsActionCameraEnableActionCam",
 		"InterfaceOptionsActionCameraHeadBob",
-		"InterfaceOptionsActionCameraFocusInteractable",
+		"InterfaceOptionsActionCameraFocusInteractable", -- old name?
+		"InterfaceOptionsActionCameraFocusInteract",
 		"InterfaceOptionsActionCameraFocusTarget",
+
 		"InterfaceOptionsMouseoverCastPanelMouseoverCastFriendly",
 		"InterfaceOptionsMouseoverCastPanelMouseoverCastHarm",
+
+		"InterfaceOptionsLoseControlPanelEnabled",
+		"InterfaceOptionsLoseControlPanelEnableRoots",
+		"InterfaceOptionsLoseControlPanelEnableDisorient",
+		"InterfaceOptionsLoseControlPanelEnableSilence",
+		"InterfaceOptionsLoseControlPanelEnableSlow",
+		"InterfaceOptionsLoseControlPanelEnableIncap",
+		"InterfaceOptionsLoseControlPanelEnableStun",
+		"InterfaceOptionsLoseControlPanelEnableDisarm",
+		"InterfaceOptionsLoseControlPanelEnablePacify",
+
+		"CompactUnitFrameProfilesRaidStylePartyFrames",
+		"CompactUnitFrameProfilesGeneralOptionsFrameKeepGroupsTogether",
+		"CompactUnitFrameProfilesGeneralOptionsFrameDisplayIncomingHeals",
+		"CompactUnitFrameProfilesGeneralOptionsFrameDisplayPowerBar",
+		"CompactUnitFrameProfilesGeneralOptionsFrameDisplayAggroHighlight",
+		"CompactUnitFrameProfilesGeneralOptionsFrameUseClassColors",
+		"CompactUnitFrameProfilesGeneralOptionsFrameUsePrimaryStatColors",
+		"CompactUnitFrameProfilesGeneralOptionsFrameDisplayPets",
+		"CompactUnitFrameProfilesGeneralOptionsFrameDisplayMainTankAndAssist",
+		"CompactUnitFrameProfilesGeneralOptionsFrameDisplayBorder",
+		"CompactUnitFrameProfilesGeneralOptionsFrameShowDebuffs",
+		"CompactUnitFrameProfilesGeneralOptionsFrameDisplayOnlyDispellableDebuffs",
+
+		"CompactUnitFrameProfilesGeneralOptionsFrameAutoActivate2Players",
+		"CompactUnitFrameProfilesGeneralOptionsFrameAutoActivate3Players",
+		"CompactUnitFrameProfilesGeneralOptionsFrameAutoActivate5Players",
+		"CompactUnitFrameProfilesGeneralOptionsFrameAutoActivate10Players",
+		"CompactUnitFrameProfilesGeneralOptionsFrameAutoActivate15Players",
+		"CompactUnitFrameProfilesGeneralOptionsFrameAutoActivate25Players",
+		"CompactUnitFrameProfilesGeneralOptionsFrameAutoActivate40Players",
+		"CompactUnitFrameProfilesGeneralOptionsFrameAutoActivatePvP",
+		"CompactUnitFrameProfilesGeneralOptionsFrameAutoActivatePvE",
 
 		"AudioOptionsSoundPanelEnableSound",
 		"AudioOptionsSoundPanelSoundEffects",
@@ -304,6 +401,7 @@ S:AddCallback("Skin_BlizzardOptions", function()
 
 		"InterfaceOptionsAscensionHelpPanelNewPlayerExperience",
 		"InterfaceOptionsAscensionHelpPanelHelpTips"
+
 	}
 	for _, checkbox in ipairs(checkboxes) do
 		checkbox = _G[checkbox]
@@ -313,19 +411,33 @@ S:AddCallback("Skin_BlizzardOptions", function()
 	end
 
 	local sliders = {
+		"InterfaceOptionsControlsPanelTabTargetRange",
+		"InterfaceOptionsControlsPanelTabTargetAngle",
+
+		"InterfaceOptionsCombatPanelSpellActivationOverlayAlpha", -- Old Name?
+		"InterfaceOptionsCombatPanelSpellActivationOverlays",
+
+		"InterfaceOptionsObjectivesPanelLootArtScale",
+
+		"InterfaceOptionsMousePanelMouseLookSpeedSlider",
+		"InterfaceOptionsMousePanelMouseSensitivitySlider",
+
+		"InterfaceOptionsNamePlatesPanelOverlapV",
+		"InterfaceOptionsNamePlatePanelIntersectOpacity", -- Old Name?
+		"InterfaceOptionsNamePlatesPanelIntersectOpacity",
+		"InterfaceOptionsNamePlatePanelNameplateDistance", -- Old Name?
+		"InterfaceOptionsNamePlatesPanelNameplateDistance",
+		"InterfaceOptionsNamePlatePanelFadeInMin", -- Removed option?
+		"InterfaceOptionsNamePlatePanelNameplateZ", -- Old Name?
+		"InterfaceOptionsNamePlatesPanelNameplateZ",
+		"InterfaceOptionsNamePlatePanelFadeInMax", -- removed option?
+
+		"InterfaceOptionsCameraPanelZoomSpeed",
 		"InterfaceOptionsCameraPanelMaxDistanceSlider",
 		"InterfaceOptionsCameraPanelFollowSpeedSlider",
 		"InterfaceOptionsCameraPanelFoV",
-		"InterfaceOptionsControlsPanelTabTargetRange",
-		"InterfaceOptionsControlsPanelTabTargetAngle",
-		"InterfaceOptionsCombatPanelSpellActivationOverlayAlpha",
-		"InterfaceOptionsMousePanelMouseLookSpeedSlider",
-		"InterfaceOptionsMousePanelMouseSensitivitySlider",
-		"InterfaceOptionsNamePlatePanelIntersectOpacity",
-		"InterfaceOptionsNamePlatePanelNameplateDistance",
-		"InterfaceOptionsNamePlatePanelFadeInMin",
-		"InterfaceOptionsNamePlatePanelNameplateZ",
-		"InterfaceOptionsNamePlatePanelFadeInMax",
+		"InterfaceOptionsCameraPanelM2CollisionAlpha",
+
 		"InterfaceOptionsActionCameraAngle",
 		"InterfaceOptionsActionCameraHeight",
 		"InterfaceOptionsActionCameraMinPitch",
@@ -333,6 +445,11 @@ S:AddCallback("Skin_BlizzardOptions", function()
 		"InterfaceOptionsActionCameraTurnSpeed",
 		"InterfaceOptionsActionCameraMaxPitch",
 		
+		"InterfaceOptionsAscensionNotificationPanelLootToastMaximum",
+
+		"CompactUnitFrameProfilesGeneralOptionsFrameHeightSlider",
+		"CompactUnitFrameProfilesGeneralOptionsFrameWidthSlider", 
+
 		"AudioOptionsSoundPanelSoundQuality",
 		"AudioOptionsSoundPanelSoundChannels",
 		"AudioOptionsSoundPanelMasterVolume",
@@ -356,6 +473,7 @@ S:AddCallback("Skin_BlizzardOptions", function()
 		"VideoOptionsExtendedForegroundFPS",
 		"VideoOptionsExtendedBackgroundFPS",
 		"VideoOptionsResolutionPanelGammaSlider",
+
 	}
 	for _, slider in ipairs(sliders) do
 		S:HandleSliderFrame(_G[slider])
@@ -376,10 +494,19 @@ S:AddCallback("Skin_BlizzardOptions", function()
 		"VideoOptionsFrameCancel",
 		"VideoOptionsFrameApply",
 
-		"InterfaceOptionsAscensionLoseControlPanelMoveWindow",
-		"InterfaceOptionsAscensionLoseControlPanelResetWindow",
+		"InterfaceOptionsAscensionLoseControlPanelMoveWindow", -- old Name?
+		"InterfaceOptionsAscensionLoseControlPanelResetWindow", -- old Name?
+		"InterfaceOptionsLoseControlPanelMoveWindow",
+		"InterfaceOptionsLoseControlPanelResetWindow",
+
 		"InterfaceOptionsAscensionHelpPanelResetTutorials",
-		"InterfaceOptionsAscensionHelpPanelResetHelpTips"
+		"InterfaceOptionsAscensionHelpPanelResetHelpTips",
+
+		"CompactUnitFrameProfilesExportButton",
+		"CompactUnitFrameProfilesImportButton",
+		"CompactUnitFrameProfilesSaveButton",
+		"CompactUnitFrameProfilesDeleteButton",
+		"CompactUnitFrameProfilesGeneralOptionsFrameResetPositionButton",
 
 	}
 	for _, button in ipairs(buttons) do
@@ -391,9 +518,10 @@ S:AddCallback("Skin_BlizzardOptions", function()
 		"InterfaceOptionsCombatPanelTOTDropDown",
 		"InterfaceOptionsCombatPanelFocusCastKeyDropDown",
 		"InterfaceOptionsCombatPanelSelfCastKeyDropDown",
-		"InterfaceOptionsDisplayPanelAggroWarningDisplay",
-		"InterfaceOptionsDisplayPanelWorldPVPObjectiveDisplay",
-		"InterfaceOptionsDisplayPanelLocalization",
+		"InterfaceOptionsDisplayPanelAggroWarningDisplay", -- Old Option?
+		"InterfaceOptionsDisplayPanelWorldPVPObjectiveDisplay", -- Old Option?
+		"InterfaceOptionsDisplayPanelLocalization", -- Old Option?
+		"InterfaceOptionsDisplayPanelSelectionCircle",
 		"InterfaceOptionsSocialPanelChatStyle",
 		"InterfaceOptionsSocialPanelTimestamps",
 		"InterfaceOptionsCombatTextPanelFCTDropDown",
@@ -406,6 +534,10 @@ S:AddCallback("Skin_BlizzardOptions", function()
 
 		"VideoOptionsResolutionPanelResolutionDropDown",
 		"VideoOptionsResolutionPanelRefreshDropDown",
+
+		"CompactUnitFrameProfilesProfileSelector",
+		"CompactUnitFrameProfilesGeneralOptionsFrameSortByDropdown",
+		"CompactUnitFrameProfilesGeneralOptionsFrameHealthTextDropdown", 
 	}
 	for _, dropdown in ipairs(dropdowns) do
 		dropdown = _G[dropdown]

--- a/ElvUI/Modules/Skins/Blizzard/LFD.lua
+++ b/ElvUI/Modules/Skins/Blizzard/LFD.lua
@@ -202,12 +202,26 @@ S:AddCallback("Skin_LFD", function()
 	-- PvP Ruleset
 	AscensionRulesetFrame:StripTextures(true)
 
-	--[[for i = 1, 3 do
+	for i = 1, 3 do
 		local pvpruleset = _G["AscensionRulesetFrameRuleset"..i]
-		--pvpruleset:StripTextures(true)
+		local inset = pvpruleset.NineSlice
+		pvpruleset:StripTextures()
+		inset:StripTextures()
+		pvpruleset:SetBackdrop({
+			bgFile = E.media.blankTex,
+			edgeFile = E.media.blankTex,
+			tile = false, tileSize = 0, edgeSize = 1,
+			insets = {left = -1, right = -1, top = -1, bottom = -1}
+		})
+		pvpruleset:SetBackdropColor(0, 0, 0, .5)
+
+		-- Set border color based on which element we're skinning (High Risk is elemenet 1)
+		local green = i > 1 and 1 or 0
+		local red = i <= 2 and 1 or 0
+		pvpruleset:SetBackdropBorderColor(green, red, 0)
+		
 		S:HandleButton(pvpruleset.Select)
 	end
-	]]--
 
 	local function skinLFDRandomDungeonLoot(frame)
 		if frame.isSkinned then return end

--- a/ElvUI/Modules/Skins/Blizzard/PathToAscension.lua
+++ b/ElvUI/Modules/Skins/Blizzard/PathToAscension.lua
@@ -43,6 +43,7 @@ S:AddCallbackForAddon("Ascension_PathToAscension", "Skin_PathToAscension", funct
 
 	S:HandleButton(PathToAscensionFrameMentorPanelBecomeMentorBecomeMentorButton)
 	S:HandleButton(PathToAscensionFrameMentorPanelFindHelpRefreshButton)
+	S:HandleButton(PathToAscensionFrameMentorPanelBecomeMentorOverlayGoToFirstTab)
 	PathToAscensionFrameMentorPanelFindHelpRefreshButton:Size(22, 22)
 
 	S:HandleScrollList(PathToAscensionFrameMentorPanelFindHelpAvailableMentors)

--- a/ElvUI/Modules/Skins/Blizzard/Worldmap.lua
+++ b/ElvUI/Modules/Skins/Blizzard/Worldmap.lua
@@ -46,6 +46,8 @@ S:AddCallback("Skin_WorldMap", function()
 	WorldMapQuestRewardScrollFrameShareButton:Width(120)
 	S:HandleButton(WorldMapQuestRewardScrollFrameAbandonButton)
 	WorldMapQuestRewardScrollFrameAbandonButton:Width(120)
+	S:HandleButton(WorldMapQuestRewardScrollFrameAbandonFrameYesButton)
+	S:HandleButton(WorldMapQuestRewardScrollFrameAbandonFrameNoButton)
 	
 
 	WorldMapQuestRewardScrollChildFrame:SetScale(1)


### PR DESCRIPTION
- Options Menu - fixes many incorrectly referenced UI elements - all checkboxes and bars should be in ElvUI styling now
- PtA Mentor - fix the overlay button not being skinned when the user is not yet able to request mentor status
- Risk Choice Panel - Re-implement skin with adjusted look to match ElvUI styling
- Worldmap - fix yes/no buttons being unskinned when abandoning a quest.

![{3A307778-F8A5-4419-9C25-1A66124D798E}](https://github.com/user-attachments/assets/79c0407c-7431-46aa-980b-02609f245fdb)

![{667A5B89-7B24-41D7-A4CF-18FE5BCB0921}](https://github.com/user-attachments/assets/f54a40cc-de47-4f54-adf3-110451e5d3e2)

![{CA5CD256-2FA3-456A-A241-738A39100B32}](https://github.com/user-attachments/assets/27575c46-21be-4168-84c7-91d5f5d83ab2)
