### PR TITLE
Implement Inspect and Callboard Frames

### DIFF
--- a/ElvUI/ElvUI.toc
+++ b/ElvUI/ElvUI.toc
@@ -1,6 +1,6 @@
 ## Interface: 30300
 ## Author: Elv, Bunny
-## Version: 7.21
+## Version: 7.22
 ## Title: |cff1784d1E|r|cffe5e3e3lvUI|r
 ## Notes: User Interface replacement AddOn for World of Warcraft.
 ## SavedVariables: ElvDB, ElvPrivateDB

--- a/ElvUI/Modules/Skins/Blizzard/CallBoard.lua
+++ b/ElvUI/Modules/Skins/Blizzard/CallBoard.lua
@@ -1,0 +1,41 @@
+local E, L, V, P, G = unpack(ElvUI)
+local S = E:GetModule("Skins")
+
+local unpack = unpack
+
+S:AddCallbackForAddon("AscensionUI", "Skin_CallBoard", function ()
+	if not E.private.skins.blizzard.enable or not E.private.skins.blizzard.callboard then return end
+
+    CallBoardUI:StripTextures()
+    CallBoardUINineSlice:StripTextures()
+
+    CallBoardUI.Tabs:StripTextures()
+    CallBoardUI.content:StripTextures()
+    CallBoardUI.content.TotalRewards.controlFrame:StripTextures()
+
+	-- Strip Border Textures
+    CallBoardUI.Tabs.NineSlice:StripTextures()
+    CallBoardUI.content.NineSlice:StripTextures()
+    CallBoardUI.content.TotalRewards:StripTextures()
+    
+    CallBoardUI.content.TotalRewards.NineSlice:StripTextures()
+    CallBoardUI.content.ExtraSlots.Scroll.scrollTop:StripTextures()
+    CallBoardUI.content.ExtraSlots.Scroll.scrollMid:StripTextures()
+    CallBoardUI.content.ExtraSlots.Scroll.scrollBot:StripTextures()
+    CallBoardUI.content.ExtraSlots.Scroll.scrollBG:StripTextures()
+    
+    local tabs = {CallBoardUI.Tabs:GetChildren()}
+
+    -- Reskin the Frames in ElvUI style
+    CallBoardUI:CreateBackdrop("Transparent")
+    CallBoardUI.content.NineSlice:CreateBackdrop("Transparent")
+    -- Fix NineSlice borderframe overlaying at the wrong FrameLevel
+    CallBoardUI.content.NineSlice:SetFrameLevel(CallBoardUI.content:GetFrameLevel())
+
+	S:HandleCloseButton(CallBoardUICloseButton)
+    S:HandleScrollBar(CallBoardUI.content.ExtraSlots.Scroll.scrollBar)
+    S:HandleScrollBar(CallBoardUI.content.statisticsScroll.ScrollBar)
+    S:HandleButton(CallBoardUI.content.TotalRewards.controlFrame.buttonAccept, true)
+    S:HandleButton(CallBoardUI.content.TotalRewards.controlFrame.buttonComplete, true)
+
+end)

--- a/ElvUI/Modules/Skins/Blizzard/Load_Blizzard.xml
+++ b/ElvUI/Modules/Skins/Blizzard/Load_Blizzard.xml
@@ -10,6 +10,7 @@
 	<Script file="BGScore.lua"/>
 	<Script file="Binding.lua"/>
 	<Script file="BlizzardOptions.lua"/>
+	<Script file="CallBoard.lua"/>
 	<Script file="Calendar.lua"/>
 	<Script file="Character.lua"/>
 	<Script file="Debug.lua"/>

--- a/ElvUI/Settings/Private.lua
+++ b/ElvUI/Settings/Private.lua
@@ -73,6 +73,7 @@ V.skins = {
 		binding = true,
 		BlizzardOptions = true,
 		calendar = true,
+		callboard = true,
 		character = true,
 		debug = true,
 		dressingroom = true,

--- a/ElvUI_OptionsUI/Skins.lua
+++ b/ElvUI_OptionsUI/Skins.lua
@@ -111,6 +111,11 @@ E.Options.args.skins = {
 					name = L["Calendar Frame"],
 					desc = L["TOGGLESKIN_DESC"]
 				},
+				callboard = {
+					type = "toggle",
+					name = L["CallBoard Frame"],
+					desc = L["TOGGLESKIN_DESC"]
+				},
 				character = {
 					type = "toggle",
 					name = L["Character Frame"],


### PR DESCRIPTION
The original ElvUI Inspect frame skinning was non-functional as Ascension re-implemented all of the Inspect frames. This PR addresses that gap by adjusting which frames and how the skinning is implemented to match the existing Character frame.
This PR also adds basic skinning of the Callboard UI.

![{16412C94-85D0-4830-A7C9-063A5F42AF75}](https://github.com/user-attachments/assets/403ea647-ed29-471d-96c7-ebd43899af9b)

![{AE51DD1E-AEBF-43D0-A32D-FD0624AE0754}](https://github.com/user-attachments/assets/6b508544-d84d-4d0b-94f3-a5076d85fa6e)

- Note: There appears to be a bug in the way the MythicEnchant Tab on the Ascension inspect frame is handled as it force-reskins itself.