### PR TITLE
fix error RegisterBucketEvent

### DIFF
--- a/ElvUI/Modules/DataTexts/DataTexts.lua
+++ b/ElvUI/Modules/DataTexts/DataTexts.lua
@@ -212,7 +212,7 @@ function DT:AssignPanelToDataText(panel, data)
 				if not callback then
 					callback = function(arg) data.eventFunc(panel, arg) end
 				end
-				panel:RegisterBucketEvent(event, period, callback)
+				AceBucket:RegisterBucketEvent(event, period, callback)
 			end
 		end
 	end


### PR DESCRIPTION
when register dt like 
```lua
DT:RegisterDatatext("Bags", {"PLAYER_ENTERING_WORLD", buckets = {{ "BAG_UPDATE", 0.2 }}}, OnEvent, nil, OnClick, OnEnter, nil, L["Bags"])
```
and set it in panel throw that error
```lua
1x ElvUI\Modules\DataTexts\DataTexts.lua:215: attempt to call method 'RegisterBucketEvent' (a nil value)


Realm: Bronzebeard - Warcraft Reborn
Locale: enUS
```