### PR TITLE
Grays out enemy npc nameplates when tapped

### DIFF
--- a/ElvUI/Modules/Nameplates/Elements/Health.lua
+++ b/ElvUI/Modules/Nameplates/Elements/Health.lua
@@ -39,7 +39,8 @@ function NP:Health_UpdateColor(_, unit)
 		element.r, element.g, element.b = r, g, b -- save these for the style filter to switch back
 	end
 
-	if UnitIsTapped(unit) and not UnitIsTappedByPlayer(unit) and not UnitIsPlayer(unit) and not UnitIsDeadOrGhost(unit) then
+	local db = NP:PlateDB(self)
+	if db.greyTappedTargets and UnitIsTapped(unit) and not UnitIsTappedByPlayer(unit) and not UnitIsPlayer(unit) and not UnitIsDeadOrGhost(unit) then
 		r, g, b = 0.5, 0.5, 0.5
 		element.r, element.g, element.b = r, g, b
 	end

--- a/ElvUI/Settings/Profile.lua
+++ b/ElvUI/Settings/Profile.lua
@@ -670,7 +670,9 @@ P.nameplates = {
 			markTanks = true,
 		},
 		FRIENDLY_NPC = {},
-		ENEMY_NPC = {},
+		ENEMY_NPC = {
+			greyTappedTargets = true,
+		},
 	},
 }
 

--- a/ElvUI_OptionsUI/Nameplates.lua
+++ b/ElvUI_OptionsUI/Nameplates.lua
@@ -67,6 +67,9 @@ local function GetUnitSettings(unit, name)
 	group.args.general.args.visibilityShortcut = ACH:Execute(L["Visibility"], nil, 100, function() ACD:SelectGroup('ElvUI', 'nameplates', 'generalGroup', 'general', 'plateVisibility') end)
 	group.args.general.args.nameOnly = ACH:Toggle(L["Name Only"], nil, 101)
 	group.args.general.args.showTitle = ACH:Toggle(L["Show Title"], L["Title will only appear if Name Only is enabled or triggered in a Style Filter."], 102)
+	if unit == 'ENEMY_NPC' then
+		group.args.general.args.greyTappedTargets = ACH:Toggle(L["Grey Tapped Targets"], L["Make tapped targets appear greyed out."], 103)
+	end
 	group.args.general.args.smartAuraPosition = ACH:Select(L["Smart Aura Position"], L["Will show Buffs in the Debuff position when there are no Debuffs active, or vice versa."], 104, C.Values.SmartAuraPositions)
 
 	group.args.healthGroup = ACH:Group(L["Health"], nil, 2, nil, function(info) return E.db.nameplates.units[unit].health[info[#info]] end, function(info, value) E.db.nameplates.units[unit].health[info[#info]] = value NP:ConfigureAll() end)


### PR DESCRIPTION
Adds a feature to grey out enemy NPCs that have been tapped by other players.

Includes a toggle in Nameplates → Enemy NPC → General to allow players to disable this feature if desired. The feature is enabled by default.

<img width="557" height="252" alt="image" src="https://github.com/user-attachments/assets/f329d720-4eea-4c16-b922-f99183ec4124" />

<img width="896" height="518" alt="image" src="https://github.com/user-attachments/assets/df8112b3-0924-4149-9389-f2f979d8a65d" />
