### PR TITLE
Fix factioncolor tag GetUnitBattlefieldFaction error

### DIFF
--- a/ElvUI/Core/Tags.lua
+++ b/ElvUI/Core/Tags.lua
@@ -835,7 +835,7 @@ do
 	}
 
 	E:AddTag('factioncolor', 'UNIT_NAME_UPDATE UNIT_FACTION', function(unit)
-		local englishFaction = E:GetUnitBattlefieldFaction(unit)
+		local englishFaction = (GetUnitBattlefieldFaction and GetUnitBattlefieldFaction(unit)) or UnitFactionGroup(unit)
 		return factionColors[englishFaction or '']
 	end)
 end


### PR DESCRIPTION
## Description
Fixes Lua error: "attempt to call method 'GetUnitBattlefieldFaction' (a nil value)" at `Core/Tags.lua:838`

## Root Cause
The `factioncolor` tag was incorrectly calling `E:GetUnitBattlefieldFaction(unit)` as a method on the E object, but this method doesn't exist in the codebase.

## Changes
- Changed from `E:GetUnitBattlefieldFaction(unit)` to call the global WoW API function directly
- Added nil check for `GetUnitBattlefieldFaction` in case the API function isn't available
- Added fallback to `UnitFactionGroup(unit)` for compatibility

## Testing
- Tested in-game on Ascension (Bronzebeard - Warcraft Reborn)
- Error no longer occurs when targeting units
- Faction colors display correctly on unit frames

## Error Details

Interface\AddOns\ElvUI\Core\Tags.lua:838: attempt to call method 'GetUnitBattlefieldFaction' (a nil value)