### PR TITLE
fix(skins): add safety check for uninitialized bags db in guild bank

### DIFF
--- a/ElvUI/Modules/Skins/Blizzard/GuildBank.lua
+++ b/ElvUI/Modules/Skins/Blizzard/GuildBank.lua
@@ -125,17 +125,19 @@ S:AddCallbackForAddon("Blizzard_GuildBankUI", "Skin_Blizzard_GuildBankUI", funct
 			end
 
 			if link and button then
-				-- Prepare scan tooltip for bind type detection (if enabled)
-				if B.db.showBindType then
-					E.ScanTooltip:SetOwner(UIParent, "ANCHOR_NONE")
-					E.ScanTooltip:SetGuildBankItem(tab, i)
-					E.ScanTooltip:Show()
+				if B.db then
+					-- Prepare scan tooltip for bind type detection (if enabled)
+					if B.db.showBindType then
+						E.ScanTooltip:SetOwner(UIParent, "ANCHOR_NONE")
+						E.ScanTooltip:SetGuildBankItem(tab, i)
+						E.ScanTooltip:Show()
+					end
+
+					-- Reuse Bags appearance logic on guild bank button
+					B:UpdateSlotAppearance(button, link)
+
+					E.ScanTooltip:Hide()
 				end
-
-				-- Reuse Bags appearance logic on guild bank button
-				B:UpdateSlotAppearance(button, link)
-
-				E.ScanTooltip:Hide()
 			else
 				-- Ensure it's cleared and show default border
 				if button then


### PR DESCRIPTION
## Description
This PR adds a safety check for the Bags module database (B.db) in the Guild Bank skin.

### The issue
In some scenarios (likely due to the Guild Bank UI loading early on Ascension), the GuildBankFrame_Update hook fires before the ElvUI Bags module has fully initialized its database. This lead to a Lua error: ...GuildBank.lua:129: attempt to index field 'db' (a nil value).

### The Fix
- Wrapped the logic that depends on B.db (such as showBindType check and UpdateSlotAppearance) in a conditional if B.db then ... end.
- This prevents the UI from crashing during initial load while ensuring skinning functionality resumes once the module is ready.