### PR TITLE
fix(MoveAnything): nil-guard MAMover and MAMove frame loops

### DIFF
--- a/ElvUI_AddOnSkins/Skins/Addons/moveAnything.lua
+++ b/ElvUI_AddOnSkins/Skins/Addons/moveAnything.lua
@@ -26,10 +26,14 @@ S:AddCallbackForAddon("MoveAnything", "MoveAnything", function()
 	end
 
 	for i = 1, 20 do
-		_G["MAMover" .. i .. "Backdrop"]:SetTemplate("Transparent")
-		_G["MAMover" .. i]:HookScript("OnShow", moverOnShow)
-		_G["MAMover" .. i]:SetScript("OnEnter", moverOnEnter)
-		_G["MAMover" .. i]:SetScript("OnLeave", moverOnLeave)
+		local mover = _G["MAMover" .. i]
+		local backdrop = _G["MAMover" .. i .. "Backdrop"]
+		if mover and backdrop then
+			backdrop:SetTemplate("Transparent")
+			mover:HookScript("OnShow", moverOnShow)
+			mover:SetScript("OnEnter", moverOnEnter)
+			mover:SetScript("OnLeave", moverOnLeave)
+		end
 	end
 
 	MAOptions:StripTextures()
@@ -46,13 +50,17 @@ S:AddCallbackForAddon("MoveAnything", "MoveAnything", function()
 	S:HandleButton(MAOptionsSync)
 
 	for i = 1, 17 do
-		_G["MAMove" .. i .. "Backdrop"]:SetTemplate("Default")
-		S:HandleCheckBox(_G["MAMove" .. i .. "Move"])
-		S:HandleCheckBox(_G["MAMove" .. i .. "Hide"])
-		S:HandleButton(_G["MAMove" .. i .. "Reset"])
+		local moveFrame = _G["MAMove" .. i]
+		local backdrop = _G["MAMove" .. i .. "Backdrop"]
+		if moveFrame and backdrop then
+			backdrop:SetTemplate("Default")
+			S:HandleCheckBox(_G["MAMove" .. i .. "Move"])
+			S:HandleCheckBox(_G["MAMove" .. i .. "Hide"])
+			S:HandleButton(_G["MAMove" .. i .. "Reset"])
 
-		if i ~= 1 then
-			_G["MAMove" .. i]:SetPoint("TOPLEFT", "MAMove" .. (i - 1), "BOTTOMLEFT", 0, -SPACING)
+			if i ~= 1 then
+				moveFrame:SetPoint("TOPLEFT", "MAMove" .. (i - 1), "BOTTOMLEFT", 0, -SPACING)
+			end
 		end
 	end
 


### PR DESCRIPTION
## Summary

Add nil checks to both loops in the MoveAnything skin that iterate over `MAMover[1..20]` and `MAMove[1..17]` global frames. Without these checks, ElvUI AddOnSkins throws a nil-index error when MoveAnything is enabled but few other addons are active at login.

## Root Cause Analysis

**Error:** `attempt to index field '?' (a nil value)`

**Location:** `ElvUI_AddOnSkins/Skins/Addons/moveAnything.lua`, lines 29-32 and 49-52

MoveAnything creates mover and move frames dynamically at runtime — one pair per addon it manages. It does not create 20 MAMover slots or 17 MAMove slots upfront; it only creates as many as there are enabled addons to move. When ElvUI's AddOnSkins callback fires at login, if only a handful of addons are enabled, the vast majority of `_G["MAMover" .. i]` and `_G["MAMove" .. i]` entries are `nil`.

The original code blindly indexed these globals without checking existence first:

```lua
-- MAMover loop (original)
for i = 1, 20 do
    _G["MAMover" .. i .. "Backdrop"]:SetTemplate("Transparent")  -- nil if i > active movers
    _G["MAMover" .. i]:HookScript("OnShow", moverOnShow)         -- nil crash here
end

-- MAMove loop (original)
for i = 1, 17 do
    _G["MAMove" .. i .. "Backdrop"]:SetTemplate("Default")     -- nil crash here too
    ...
end
```

**Trigger conditions:**
- MoveAnything is enabled in the client's addon list
- Fewer than 20 addons are being moved by MoveAnything (common — most users only move a handful)
- ElvUI AddOnSkins has the MoveAnything skin enabled

## Fix

Guard both loops with existence checks before attempting to call methods on the frame objects:

```lua
for i = 1, 20 do
    local mover = _G["MAMover" .. i]
    local backdrop = _G["MAMover" .. i .. "Backdrop"]
    if mover and backdrop then
        backdrop:SetTemplate("Transparent")
        mover:HookScript("OnShow", moverOnShow)
        mover:SetScript("OnEnter", moverOnEnter)
        mover:SetScript("OnLeave", moverOnLeave)
    end
end
```

```lua
for i = 1, 17 do
    local moveFrame = _G["MAMove" .. i]
    local backdrop = _G["MAMove" .. i .. "Backdrop"]
    if moveFrame and backdrop then
        backdrop:SetTemplate("Default")
        S:HandleCheckBox(_G["MAMove" .. i .. "Move"])
        S:HandleCheckBox(_G["MAMove" .. i .. "Hide"])
        S:HandleButton(_G["MAMove" .. i .. "Reset"])
        if i ~= 1 then
            moveFrame:SetPoint("TOPLEFT", "MAMove" .. (i - 1), "BOTTOMLEFT", 0, -SPACING)
        end
    end
end
```

**Side-effect improvement:** The second loop previously re-indexed `_G["MAMove" .. i]` for the `SetPoint` call. The fix stores the frame in a local variable first, eliminating that redundant lookup.

## Testing

1. Enable MoveAnything with ElvUI AddOnSkins
2. Ensure only a small number of addons are checked as "movable" in MoveAnything's options (fewer than 20)
3. Reload UI — no nil-index error should appear in bugsack/bugger
4. Open MoveAnything options — all visible movers/move rows should still be properly styled
